### PR TITLE
Update to use with mlp

### DIFF
--- a/constants_and_tools.py
+++ b/constants_and_tools.py
@@ -37,7 +37,14 @@ def convert_surface_to_inequality(s, eqAsIneq):
     if n[2] <= 0.:
         for i in range(3):
             n[i] = -n[i]
-    n /= norm(n)
+    norm_n = norm(n)
+    if norm_n > 1e-6:
+        n /= norm(n)
+    else:
+        # FIXME: to something better here
+        print("WARNING: the norm of a normal vector was null, use default value along Z axis")
+        print("vector was : ",n)
+        n = array([0,0,1])
     return surfacePointsToIneq(s, n, eqAsIneq)
     
 def replace_surfaces_with_ineq_in_phaseData(phase, eqAsIneq):

--- a/constants_and_tools.py
+++ b/constants_and_tools.py
@@ -163,7 +163,7 @@ def surfacePointsToIneq(S, normal, eqAsIneq):
         A = vstack([ine.A, n])
         b = concatenate([ine.b, d]).reshape((-1,))
         
-    return A, b
+    return A, b, n
     
 ############ BENCHMARKING ###############
 

--- a/constants_and_tools.py
+++ b/constants_and_tools.py
@@ -44,9 +44,16 @@ def convert_surface_to_inequality(s, eqAsIneq):
         # FIXME: to something better here
         print("WARNING: the norm of a normal vector was null, use default value along Z axis")
         print("vector was : ",n)
+        print("surface was : ",s)
         n = array([0,0,1])
     return surfacePointsToIneq(s, n, eqAsIneq)
-    
+
+def normal_from_ineq(s_ineq):
+    n = s_ineq[0][-1]
+    if n[2] < 0:
+        n = -n
+    return n
+
 def replace_surfaces_with_ineq_in_phaseData(phase, eqAsIneq):
     phase["S"] = [convert_surface_to_inequality(S, eqAsIneq) for S in phase["S"]]
     

--- a/fix_sparsity.py
+++ b/fix_sparsity.py
@@ -21,7 +21,7 @@ except ImportError:
 
 from time import clock
 
-np.set_printoptions(formatter={'float': lambda x: "{0:0.1f}".format(x)})
+#np.set_printoptions(formatter={'float': lambda x: "{0:0.1f}".format(x)})
 
 
 

--- a/planner_l1_generic_equalities_as_ineq.py
+++ b/planner_l1_generic_equalities_as_ineq.py
@@ -898,6 +898,16 @@ def maxStepSizeCost(pb, cVars, initPos, endPos, initCom, endCom, refPos):
         startCol = endCol
     return cost
 
+def add_selected_surfaces_to_pb(pb, bool_vars):
+    begin_phase_id = 0
+    for phase in pb["phaseData"]:
+        end_phase_id = begin_phase_id + len(phase["S"])
+        bool_vars_phase = bool_vars[begin_phase_id:end_phase_id]
+        if bool_vars_phase.count(0) != 1:
+            raise ValueError("There must be exactly one surface selected for each phase")
+        phase["id_surface"] = bool_vars_phase.index(0) # add a new field in the phase data
+        begin_phase_id = end_phase_id
+    
 
 def solveMIPGurobi(pb, surfaces, MIP = True, draw_scene = None, plot = True, initGuess = None, initGuessMip = None, l1Contact = False, initPos = None,  endPos = None, initCom = None,  endCom = None,
 costs = [(1, posturalCost),(2, targetCom)], constraint_init_pos_surface = True, refPos = None):  
@@ -1080,11 +1090,15 @@ costs = [(1, posturalCost),(2, targetCom)], constraint_init_pos_surface = True, 
     t2 = clock()
     res = [el.x for el in cVars]
     resbool = [el.x for el in boolvars]
+    resboolvarsSurf = [el.x for el in boolvarsSurf]
     print ("resbool", resbool)
     print ("time to solve MIP ", timMs(t1,t2))
     
-    
+    print("boolvarsSurf len : ", len(resboolvarsSurf))
+    print("boolvarsSurf = ", resboolvarsSurf)
     #~ return timMs(t1,t2)
+
+    add_selected_surfaces_to_pb(pb, resboolvarsSurf)
     
     return pb, res, timMs(t1,t2)
     # ~ if MIP:

--- a/planner_l1_generic_equalities_as_ineq.py
+++ b/planner_l1_generic_equalities_as_ineq.py
@@ -258,7 +258,7 @@ def SurfaceConstraint(phaseDataT, A, b, startCol, endCol, startRow):
     sRow = startRow
     nSurfaces = len(phaseDataT["S"])
     idS = ALPHA_START
-    for (S,s) in phaseDataT["S"]:   
+    for (S,s,_) in phaseDataT["S"]:   
         for footId in range(N_EFFECTORS):
             idRow = sRow + S.shape[0]
             # Sl pi - M alphal <= sl + M2 (1 - w_t)

--- a/planner_l1_generic_equalities_as_ineq.py
+++ b/planner_l1_generic_equalities_as_ineq.py
@@ -901,12 +901,15 @@ def maxStepSizeCost(pb, cVars, initPos, endPos, initCom, endCom, refPos):
 def add_selected_surfaces_to_pb(pb, bool_vars):
     begin_phase_id = 0
     for phase in pb["phaseData"]:
-        end_phase_id = begin_phase_id + len(phase["S"])
-        bool_vars_phase = bool_vars[begin_phase_id:end_phase_id]
-        if bool_vars_phase.count(0) != 1:
-            raise ValueError("There must be exactly one surface selected for each phase")
-        phase["id_surface"] = bool_vars_phase.index(0) # add a new field in the phase data
-        begin_phase_id = end_phase_id
+        if len(phase["S"]) == 1:
+            phase["id_surface"] = 0
+        else:
+            end_phase_id = begin_phase_id + len(phase["S"])
+            bool_vars_phase = bool_vars[begin_phase_id:end_phase_id]
+            if bool_vars_phase.count(0) != 1:
+                raise ValueError("There must be exactly one surface selected for each phase")
+            phase["id_surface"] = bool_vars_phase.index(0) # add a new field in the phase data
+            begin_phase_id = end_phase_id
     
 
 def solveMIPGurobi(pb, surfaces, MIP = True, draw_scene = None, plot = True, initGuess = None, initGuessMip = None, l1Contact = False, initPos = None,  endPos = None, initCom = None,  endCom = None,

--- a/sl1m_to_mcapi.py
+++ b/sl1m_to_mcapi.py
@@ -1,0 +1,128 @@
+from multicontact_api import ContactSequence, ContactPhase, ContactPatch
+from pinocchio import SE3, Quaternion
+import numpy as np
+from numpy.linalg import norm
+
+# Hardcoded data for solo !
+rLegId = 'FRleg'
+rleg = 'FR_HAA'
+rfoot = 'FR_FOOT'
+lLegId = 'FLleg'
+lleg = 'FL_HAA'
+lfoot = 'FL_FOOT'
+lArmId = 'HLleg'
+larm = 'HL_HAA'
+lhand = 'HL_FOOT'
+rArmId = 'HRleg'
+rarm = 'HR_HAA'
+rhand = 'HR_FOOT'
+limbs_names = [rArmId, rLegId, lArmId, lLegId]  # List of effector used to create contact
+dict_limb_joint = {rLegId: rfoot, lLegId: lfoot, rArmId: rhand, lArmId: lhand}
+offset = [0., 0., -0.018]  # Contact position in the effector frame
+# various offset used by scripts
+MRsole_offset = SE3.Identity()
+MRsole_offset.translation = np.matrix(offset).T
+MLsole_offset = MRsole_offset.copy()
+MRhand_offset = MRsole_offset.copy()
+MLhand_offset = MRsole_offset.copy()
+dict_offset = {rfoot: MRsole_offset, lfoot: MLsole_offset, rhand: MRhand_offset, lhand: MLhand_offset}
+DEFAULT_COM_HEIGHT = 0.2
+
+def normal_from_ineq(s_ineq):
+    return s_ineq[2]
+
+
+def rotationFromNormal(n):
+    """
+    return a rotation matrix corresponding to the given contact normal
+    :param n: the normal of the surface (as a numpy array)
+    :return: a rotation matrix
+    """
+    z_up = np.array([0., 0., 1.])
+    q = Quaternion.FromTwoVectors(z_up, n)
+    return q.matrix()
+
+
+def computeCenterOfSupportPolygonFromPhase(phase, DEFAULT_HEIGHT):
+    """
+    Compute 3D point in the center of the support polygon and at a given height
+    :param phase: the ContactPhase used to compute the support polygon
+    :param DEFAULT_HEIGHT: the height of the returned point
+    :return: a numpy array of size 3
+    """
+    com = np.zeros(3)
+    for patch in phase.contactPatches().values():
+        com += patch.placement.translation
+    com /= phase.numContacts()
+    com[2] += DEFAULT_HEIGHT
+    return com
+
+def placement_from_sl1m(ee_name, pos, phase_data):
+    #pos[2] += EPS_Z # FIXME: apply epsz along the normal
+    pos = dict_offset[ee_name].actInv(pos)
+    print("Move effector ", ee_name)
+    print("To position ", pos)
+    placement = SE3.Identity()
+    placement.translation = pos
+    # compute orientation of the contact from the surface normal:
+    n = normal_from_ineq(phase_data["S"][phase_data["id_surface"]])
+    placement.rotation = rotationFromNormal(n)
+    print("new contact placement : ", placement)
+    # TODO add yaw rotation from guide here !
+    return placement
+
+
+def build_cs_from_sl1m_mip(pb, allfeetpos):
+    # init contact sequence with first phase : q_ref move at the right root pose and with both feet in contact
+    # FIXME : allow to customize that first phase
+    num_steps = len(pb["phaseData"]) - 1 # number of contact repositionning
+    num_effectors = len(limbs_names)
+    print(" limbs names : ", limbs_names)
+    cs = ContactSequence(0)
+    # create the first contact phase :
+    cp_init = ContactPhase()
+    for k, pos in enumerate(allfeetpos[0]):
+        phase_data = pb["phaseData"][0]
+        ee_name = dict_limb_joint[limbs_names[k]]
+        cp_init.addContact(ee_name, ContactPatch(placement_from_sl1m(ee_name, pos, phase_data)))
+    cs.append(cp_init)
+    print("Initial phase added, contacts : ", cs.contactPhases[0].effectorsInContact())
+    # loop for all effector placements, and create the required contact phases
+    previous_eff_placements = allfeetpos[0]
+    if len(previous_eff_placements) != num_effectors:
+        raise NotImplementedError("A phase in the output of SL1M do not have all the effectors in contact.")
+    for pid, eff_placements in enumerate(allfeetpos[1:]):
+        print("Loop allfeetpos, id = ", pid)
+        if len(eff_placements) != num_effectors:
+            raise NotImplementedError("A phase in the output of SL1M do not have all the effectors in contact.")
+        switch = False # True if a repostionning have been detected
+        for k, pos in enumerate(eff_placements):
+            if norm(pos - previous_eff_placements[k]) > 1e-3:
+                if switch:
+                    raise NotImplementedError("Several contact changes between two adjacent phases in SL1M output")
+                switch = True
+                ee_name = dict_limb_joint[limbs_names[k]]
+                phase_data = pb["phaseData"][pid+1] # +1 because the for loop start at id = 1
+                placement = placement_from_sl1m(ee_name, pos, phase_data)
+                cs.moveEffectorToPlacement(ee_name, placement)
+
+        if not switch:
+           raise RuntimeError("No contact changes between two adjacent phases in SL1M output")
+        # assign com position to the last two phases :
+        # swinging phase, same init and final position
+        """
+        cs.contactPhases[-2].c_init = coms[pid * 2]
+        cs.contactPhases[-2].c_final = coms[pid * 2 + 1]
+        # phase with all the contacts:
+        cs.contactPhases[-1].c_init = coms[pid * 2 + 1]
+        if pid * 2 + 2 < len(coms):
+            cs.contactPhases[-1].c_final = coms[pid * 2 + 2]
+        else:
+            cs.contactPhases[-1].c_final = cs.contactPhases[-1].c_init
+        """
+        previous_eff_placements = eff_placements
+    p_final = cs.contactPhases[-1]
+    p_final.c_final = computeCenterOfSupportPolygonFromPhase(p_final, DEFAULT_COM_HEIGHT)
+    p_final.c_init = p_final.c_final
+    return cs
+

--- a/tools/transformations.py
+++ b/tools/transformations.py
@@ -1917,6 +1917,5 @@ _import_module('transformations')
 if __name__ == "__main__":
     import doctest
     import random  # used in doctests
-    numpy.set_printoptions(suppress=True, precision=5)
     doctest.testmod()
 


### PR DESCRIPTION
* `convertProblemToLp`, `solveMIP` and `solveMIPGurobi` take an extra optional argument `constraint_init_pos_surface` (default value is similar to the previous behavior). 
If `constraint_init_pos_surface` is True, the contacts of the first phase are not constrained to belong to the given surface candidates.
* Remove the call to numpy print_option that truncated all the outputs of float from numpy. 
* Store the selected surface by MIP inside the PhaseDat dict
* Store the surface normal in the phaseData[S] list
* Add a script to convert output of SL1M to multicontact API ContactSequence object