### PR TITLE
[Fix] getSurfacesFromGuide adding wrong surfaces to sequence.

### DIFF
--- a/sl1m/rbprm/surfaces_from_planning.py
+++ b/sl1m/rbprm/surfaces_from_planning.py
@@ -133,7 +133,7 @@ def getSurfacesFromGuideContinuous(rbprmBuilder, ps, afftool, pathId, viewer=Non
                 if not name_contact in seq_name:
                     seq.append(surfaces_dict[name_contact][0]) # Add entire surface
                     seq_name.append(name_contact)
-        sorted(seq)
+        seq.sort()
         seqs.append(seq)
         # increase value for the next phase
         t = current_phase_end
@@ -196,6 +196,7 @@ def getSurfacesFromGuide(rbprmBuilder, ps, afftool, pathId, viewer=None, step=0.
                 seq.append(surface_dict[contact_names[j]][0])
             if viewer:
                 displaySurfaceFromPoints(viewer, contact, [0, 0, 1, 1])
+        seq.sort()
         seqs.append(seq)
 
     # remove duplicates


### PR DESCRIPTION
[Fix] getSurfacesFromGuide and continuous functions not adding the right surfaces to the sequence, as step_contacts and step_contacts_names are not in the same order. On two different runs, the functions return the lists in random orders. 

Fix : find the surface associated to each intersection and reorder these lists.

Problem can be reproduced on the previous version : https://github.com/loco-3d/sl1m/blob/devel/sl1m/planner_scenarios/talos/stairs.py
set ``USE_MIP=False`` and add ``print("last 2 right foot pos : ",result.all_feet_pos[0][-2:])`` at line 60.
Run test file two or three times ``ipython3 stairs.py``, the foot positions printed should be the same, but it's not.

This needs to be fixed in rbprm-corba. These two functions needs to return the intersections and the names of the corresponding surfaces in the same order :
https://github.com/humanoid-path-planner/hpp-rbprm-corba/blob/3a39a6b3e5ffaebd19fc346144e52aa504cdcf88/src/rbprmbuilder.impl.cc#L1360
https://github.com/humanoid-path-planner/hpp-rbprm-corba/blob/3a39a6b3e5ffaebd19fc346144e52aa504cdcf88/src/rbprmbuilder.impl.cc#L1315

List of surfaces were not sorted. Problem with MIP for which the order of surfaces for each phase impacts the exploration (number of nodes explored, computation time).